### PR TITLE
Remove KeycloakClient's static initializer

### DIFF
--- a/src/Keycloak.Net/KeycloakClient.cs
+++ b/src/Keycloak.Net/KeycloakClient.cs
@@ -16,15 +16,6 @@ namespace Keycloak.Net
             NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore
         });
 
-        static KeycloakClient()
-        {
-            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore
-            };
-        }
-
         private readonly Url _url;
         private readonly string _userName;
         private readonly string _password;
@@ -47,7 +38,7 @@ namespace Keycloak.Net
         {
             _getToken = getToken;
         }
-        
+
         private IFlurlRequest GetBaseUrl(string authenticationRealm) => new Url(_url)
             .AppendPathSegment("/auth")
             .ConfigureRequest(settings => settings.JsonSerializer = s_serializer)


### PR DESCRIPTION
Description:
  Given that an instance of NewtonsoftJsonSerializer that has camel
  casing enabled is being passed to Flurl, the assignment to
  JsonConvert.DefaultSettings is unnecessary. It also has the potential to
  cause unintentional side effects in other applications that may depend on
  Keycloak.Net if it remains in place.

Resolves #11 