### PR TITLE
adding endpoint to get token from identity provider

### DIFF
--- a/src/Keycloak.Net/IdentityProviders/KeycloakClient.cs
+++ b/src/Keycloak.Net/IdentityProviders/KeycloakClient.cs
@@ -34,6 +34,17 @@ namespace Keycloak.Net
             .GetJsonAsync<IdentityProvider>()
             .ConfigureAwait(false);
 
+        /// <summary>
+        /// <see cref="https://github.com/keycloak/keycloak-documentation/blob/master/server_development/topics/identity-brokering/tokens.adoc"/>
+        /// </summary>
+        /// <param name="realm"></param>
+        /// <param name="identityProviderAlias"></param>
+        /// <returns></returns>
+        public async Task<IdentityProviderToken> GetIdentityProviderTokenAsync(string realm, string identityProviderAlias) => await GetBaseUrl(realm)
+            .AppendPathSegment($"/auth/realms/{realm}/broker/{identityProviderAlias}/token")
+            .GetJsonAsync<IdentityProviderToken>()
+            .ConfigureAwait(false);
+
         public async Task<bool> UpdateIdentityProviderAsync(string realm, string identityProviderAlias, IdentityProvider identityProvider)
         {
             var response = await GetBaseUrl(realm)

--- a/src/Keycloak.Net/Models/IdentityProviders/IdentityProviderToken.cs
+++ b/src/Keycloak.Net/Models/IdentityProviders/IdentityProviderToken.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+
+namespace Keycloak.Net.Models.IdentityProviders
+{
+    public class IdentityProviderToken
+    {
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; }
+
+        [JsonProperty("token_type")]
+        public string RequestingPartyToken { get; set; }
+
+        [JsonProperty("expires_in")]
+        public int ExpiresIn { get; set; }
+
+        [JsonProperty("refresh_token")]
+        public string RefreshToken { get; set; }
+
+        [JsonProperty("scope")]
+        public string Scope { get; set; }
+
+        [JsonProperty("created_at")]
+        public long CreatedAt { get; set; }
+    }
+}

--- a/test/Keycloak.Net.Tests/IdentityProviders/KeycloakClientShould.cs
+++ b/test/Keycloak.Net.Tests/IdentityProviders/KeycloakClientShould.cs
@@ -27,6 +27,14 @@ namespace Keycloak.Net.Tests
             }
         }
 
+        //[Theory]
+        //[InlineData("Insurance")]
+        //public async Task GetIdentityProviderTokenAsync(string realm)
+        //{
+        //    var token = await _client.GetIdentityProviderTokenAsync(realm).ConfigureAwait(false);
+        //    Assert.NotNull(token);
+        //}
+
         [Theory]
         [InlineData("Insurance")]
         public async Task GetIdentityProviderAuthorizationPermissionsInitializedAsync(string realm)


### PR DESCRIPTION
I was not able to add the test, this endpoint is required to get a token from the Identity Provider directly in case the client wanna make further calls to the Provider API.