### PR TITLE
Fix ClientSecret not being returned

### DIFF
--- a/src/Keycloak.Net/Clients/KeycloakClient.cs
+++ b/src/Keycloak.Net/Clients/KeycloakClient.cs
@@ -77,15 +77,15 @@ namespace Keycloak.Net
             return response.IsSuccessStatusCode;
         }
 
-        public async Task<Credential> GenerateClientSecretAsync(string realm, string clientId) => await GetBaseUrl(realm)
+        public async Task<Credentials> GenerateClientSecretAsync(string realm, string clientId) => await GetBaseUrl(realm)
             .AppendPathSegment($"/admin/realms/{realm}/clients/{clientId}/client-secret")
             .PostJsonAsync(new StringContent(""))
-            .ReceiveJson<Credential>()
+            .ReceiveJson<Credentials>()
             .ConfigureAwait(false);
 
-        public async Task<Credential> GetClientSecretAsync(string realm, string clientId) => await GetBaseUrl(realm)
+        public async Task<Credentials> GetClientSecretAsync(string realm, string clientId) => await GetBaseUrl(realm)
             .AppendPathSegment($"/admin/realms/{realm}/clients/{clientId}/client-secret")
-            .GetJsonAsync<Credential>()
+            .GetJsonAsync<Credentials>()
             .ConfigureAwait(false);
 
         public async Task<IEnumerable<ClientScope>> GetDefaultClientScopesAsync(string realm, string clientId) => await GetBaseUrl(realm)


### PR DESCRIPTION
We were parsing the json to the wrong model, which always caused it to be empty.

Closes https://github.com/lvermeulen/Keycloak.Net/issues/42