### PR TITLE
Issue 61 - Allow Keycloak administration across realms

### DIFF
--- a/src/Keycloak.Net/KeycloakClient.cs
+++ b/src/Keycloak.Net/KeycloakClient.cs
@@ -21,29 +21,33 @@ namespace Keycloak.Net
         private readonly string _password;
         private readonly string _clientSecret;
         private readonly Func<string> _getToken;
+        private readonly string _authRealm;
 
         private KeycloakClient(string url)
         {
             _url = url;
         }
 
-        public KeycloakClient(string url, string userName, string password)
+        public KeycloakClient(string url, string userName, string password, string authRealm = null)
             : this(url)
         {
             _userName = userName;
             _password = password;
+            _authRealm = authRealm;
         }
 
-        public KeycloakClient(string url, string clientSecret)
+        public KeycloakClient(string url, string clientSecret, string authRealm = null)
             : this(url)
         {
             _clientSecret = clientSecret;
+            _authRealm = authRealm;
         }
 
-        public KeycloakClient(string url, Func<string> getToken)
+        public KeycloakClient(string url, Func<string> getToken, string authRealm = null)
             : this(url)
         {
             _getToken = getToken;
+            _authRealm = authRealm;
         }
 
         public void SetSerializer(ISerializer serializer)
@@ -51,9 +55,9 @@ namespace Keycloak.Net
             _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
         }
 
-        private IFlurlRequest GetBaseUrl(string authenticationRealm) => new Url(_url)
+        private IFlurlRequest GetBaseUrl(string targetRealm) => new Url(_url)
             .AppendPathSegment("/auth")
             .ConfigureRequest(settings => settings.JsonSerializer = _serializer)
-            .WithAuthentication(_getToken, _url, authenticationRealm, _userName, _password, _clientSecret);
+            .WithAuthentication(_getToken, _url, _authRealm ?? targetRealm, _userName, _password, _clientSecret);
     }
 }


### PR DESCRIPTION
Issue 61 - Allow Keycloak administration across realms by specifying a different realm for authentication. To avoid constructor ambiguity, use named arguments. (For example: var client = new KeycloakClient("https://some.url", "tHiSiSmYcLiEnTsEcReT", authRealm: "master");)