### PR TITLE
Adds `resource` and `scopePermissions` to ManagementPermissions

### DIFF
--- a/src/Keycloak.Net/Models/Common/ManagementPermission.cs
+++ b/src/Keycloak.Net/Models/Common/ManagementPermission.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Keycloak.Net.Models.Common
 {
@@ -6,5 +7,11 @@ namespace Keycloak.Net.Models.Common
     {
         [JsonProperty("enabled")]
         public bool? Enabled { get; set; }
+        
+        [JsonProperty("resource")]
+        public string Resource { get; set; }
+
+        [JsonProperty("scopePermissions")]
+        public Dictionary<string, object> ScopePermissions { get; set; }
     }
 }


### PR DESCRIPTION
This will support getting the management permissions associated with a client. 
E.g. to get the token-exchange permission id, one needs to access `ManagementPermission.ScopePermissions["token-exchange"]`. With this id one can configure the single permission. 