### PR TITLE
Create client policy

### DIFF
--- a/src/Keycloak.Net/ClientAuthorization/KeycloakClient.cs
+++ b/src/Keycloak.Net/ClientAuthorization/KeycloakClient.cs
@@ -101,6 +101,9 @@ namespace Keycloak.Net
         #endregion 
 
         #region Policy
+        
+        #region Role Policies
+        
         public async Task<RolePolicy> CreateRolePolicyAsync(string realm, string clientId, RolePolicy policy)
         {
                 var response = await GetBaseUrl(realm)
@@ -184,6 +187,23 @@ namespace Keycloak.Net
                 .ConfigureAwait(false);
             return response.IsSuccessStatusCode;
         }
+        
+        #endregion
+        
+        #region Client Policies
+
+        public async Task<ClientPolicy> CreateClientPolicyAsync(string realm, string clientId, ClientPolicy policy)
+        {
+            var response = await GetBaseUrl(realm)
+                .AppendPathSegment($"/admin/realms/{realm}/clients/{clientId}/authz/resource-server/policy/client")
+                .PostJsonAsync(policy)
+                .ReceiveJson<ClientPolicy>()
+                .ConfigureAwait(false);
+            return response;
+        } 
+        
+        #endregion
+        
         #endregion
     }
 }

--- a/src/Keycloak.Net/Models/Clients/ClientPolicy.cs
+++ b/src/Keycloak.Net/Models/Clients/ClientPolicy.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Keycloak.Net.Models.Clients
+{
+    public class ClientPolicy : Policy
+    {
+        [JsonProperty("clients")]
+        public IEnumerable<string> Clients { get; set; }
+    }
+}

--- a/src/Keycloak.Net/Models/Clients/ClientPolicy.cs
+++ b/src/Keycloak.Net/Models/Clients/ClientPolicy.cs
@@ -5,6 +5,9 @@ namespace Keycloak.Net.Models.Clients
 {
     public class ClientPolicy : Policy
     {
+        /// <summary>
+        /// The ids of the clients. 
+        /// </summary>
         [JsonProperty("clients")]
         public IEnumerable<string> Clients { get; set; }
     }

--- a/src/Keycloak.Net/Models/Clients/Policy.cs
+++ b/src/Keycloak.Net/Models/Clients/Policy.cs
@@ -1,0 +1,38 @@
+using Keycloak.Net.Common.Converters;
+using Keycloak.Net.Models.AuthorizationPermissions;
+using Newtonsoft.Json;
+
+namespace Keycloak.Net.Models.Clients
+{
+    public class Policy
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonConverter(typeof(PolicyTypeConverter))]
+        public PolicyType Type { get; set; }
+
+        [JsonConverter(typeof(PolicyDecisionLogicConverter))]
+        public PolicyDecisionLogic Logic { get; set; } 
+
+        [JsonConverter(typeof(DecisionStrategiesConverter))]
+        public DecisionStrategy DecisionStrategy { get; set; }
+    }
+    
+    public enum PolicyType
+    {
+        Role,
+        Client,
+        Time,
+        User,
+        Aggregate,
+        Group,
+        Js
+    }
+}

--- a/src/Keycloak.Net/Models/Clients/RolePolicy.cs
+++ b/src/Keycloak.Net/Models/Clients/RolePolicy.cs
@@ -5,52 +5,16 @@ using Newtonsoft.Json;
 
 namespace Keycloak.Net.Models.Clients
 {
-    public class Policy
+    public class RolePolicy : Policy
     {
-        [JsonProperty("id")]
-        public string Id { get; set; }
-
-        [JsonProperty("name")]
-        public string Name { get; set; }
-
-        [JsonProperty("description")]
-        public string Description { get; set; }
-
         [JsonConverter(typeof(PolicyTypeConverter))]
-        public PolicyType Type { get; set; }
-
-        [JsonConverter(typeof(PolicyDecisionLogicConverter))]
-        public PolicyDecisionLogic Logic { get; set; } 
-
-        [JsonConverter(typeof(DecisionStrategiesConverter))]
-        public DecisionStrategy DecisionStrategy { get; set; }
-
-        [JsonProperty("config")]
-        public PolicyConfig Config { get; set; }
-    }
-
-    public class RolePolicy
-    {
-        [JsonProperty("id")]
-        public string Id { get; set; }
-
-        [JsonProperty("name")]
-        public string Name { get; set; }
-
-        [JsonProperty("description")]
-        public string Description { get; set; }
-
-        [JsonConverter(typeof(PolicyTypeConverter))]
-        public PolicyType Type { get; set; } = PolicyType.Role;
-
-        [JsonConverter(typeof(PolicyDecisionLogicConverter))]
-        public PolicyDecisionLogic Logic { get; set; } 
-
-        [JsonConverter(typeof(DecisionStrategiesConverter))]
-        public DecisionStrategy DecisionStrategy { get; set; }
+        public new PolicyType Type { get; set; } = PolicyType.Role;
 
         [JsonProperty("roles")]
         public IEnumerable<RoleConfig> RoleConfigs { get; set; }
+        
+        [JsonProperty("config")]
+        public PolicyConfig Config { get; set; }
     }
 
     public class RoleConfig
@@ -60,17 +24,6 @@ namespace Keycloak.Net.Models.Clients
 
         [JsonProperty("required")]
         public bool Required { get; set; }
-    }
-
-    public enum PolicyType
-    {
-        Role,
-        Client,
-        Time,
-        User,
-        Aggregate,
-        Group,
-        Js
     }
 
     public class PolicyConfig


### PR DESCRIPTION
The former implementation did only allow for Role Policies. This will do the trick for client policies as well. 
Please be aware that the former implementation did include a the `PolicyConfig Config` directly within the policy and therefore, as public class PolicyConfig contained [JsonProperty("roles")] was tied to Role policies. This was moved to `RolePolicy` and might have introduced a breaking change for a user expecting it to be part of a policy.