### PR TITLE
Added possibility to set a Custom-HttpClientHandler

### DIFF
--- a/src/Keycloak.Net/Models/Users/Credentials.cs
+++ b/src/Keycloak.Net/Models/Users/Credentials.cs
@@ -5,6 +5,8 @@ namespace Keycloak.Net.Models.Users
 {
 	public class Credentials
 	{
+		[JsonProperty("id")]
+		public string Id { get; set; }
 		[JsonProperty("algorithm")]
 		public string Algorithm { get; set; }
 		[JsonProperty("config")]

--- a/src/Keycloak.Net/Users/KeycloakClient.cs
+++ b/src/Keycloak.Net/Users/KeycloakClient.cs
@@ -59,10 +59,34 @@ namespace Keycloak.Net
 			.GetJsonAsync<int>()
 			.ConfigureAwait(false);
 
-		public async Task<User> GetUserAsync(string realm, string userId) => await GetBaseUrl(realm)
-			.AppendPathSegment($"/admin/realms/{realm}/users/{userId}")
-			.GetJsonAsync<User>()
-			.ConfigureAwait(false);
+		public async Task<User> GetUserAsync(string realm, string userId)
+		{
+			var baseUrl = GetBaseUrl(realm)
+				.AppendPathSegment($"/admin/realms/{realm}/users/{userId}");
+			var user = await baseUrl.GetJsonAsync<User>().ConfigureAwait(false);
+
+			return  user;
+		}
+
+		public async Task<List<Credentials>> GetUserCredentialsAsync(string realm, string userId)
+		{
+			var baseUrl = GetBaseUrl(realm)
+				.AppendPathSegment($"/admin/realms/{realm}/users/{userId}/credentials");
+
+			var userCredentials = await baseUrl.GetJsonAsync<List<Credentials>>().ConfigureAwait(false);
+			return userCredentials;
+		}
+
+		public async Task DeleteUserCredentialsAsync(string realm, string userId, string credentialId)
+		{
+			var baseUrl = GetBaseUrl(realm)
+				.AppendPathSegment($"/admin/realms/{realm}/users/{userId}/credentials/{credentialId}");
+
+			await baseUrl.DeleteAsync().ConfigureAwait(false);
+
+			return;
+		}
+
 
 		public async Task<bool> UpdateUserAsync(string realm, string userId, User user)
 		{


### PR DESCRIPTION
This can be used to customize the default behavior of the HttpClient. Example: Accepting untrusted SSL certificates.