### PR TITLE
Add query parameters to User Count endpoint

### DIFF
--- a/src/Keycloak.Net/Users/KeycloakClient.cs
+++ b/src/Keycloak.Net/Users/KeycloakClient.cs
@@ -54,10 +54,32 @@ namespace Keycloak.Net
 				.ConfigureAwait(false);
 		}
 
-		public async Task<int> GetUsersCountAsync(string realm) => await GetBaseUrl(realm)
-			.AppendPathSegment($"/admin/realms/{realm}/users/count")
-			.GetJsonAsync<int>()
-			.ConfigureAwait(false);
+		public async Task<int> GetUsersCountAsync(
+			string realm,
+			string email = null,
+			bool? emailVerified = null,
+			string firstName = null,
+			string lastName = null,
+			string search = null,
+			string username = null
+		)
+		{
+			var queryParams = new Dictionary<string, object>
+			{
+				[nameof(email)] = email,
+				[nameof(emailVerified)] = emailVerified,
+				[nameof(firstName)] = firstName,
+				[nameof(lastName)] = lastName,
+				[nameof(search)] = search,
+				[nameof(username)] = username
+			};
+			
+			return await GetBaseUrl(realm)
+				.AppendPathSegment($"/admin/realms/{realm}/users/count")
+				.SetQueryParams(queryParams)
+				.GetJsonAsync<int>()
+				.ConfigureAwait(false);
+		}
 
 		public async Task<User> GetUserAsync(string realm, string userId) => await GetBaseUrl(realm)
 			.AppendPathSegment($"/admin/realms/{realm}/users/{userId}")


### PR DESCRIPTION
According to the docs (https://www.keycloak.org/docs-api/17.0/rest-api/index.html#_getuserscount) you can a) specify no query parameters to return the count of all users, b) specify the `search` query parameter to filter by name email and username, or c) specify a combination of `email`, `firstName`, `lastName`, and `username` to filter the users matching the parameters specified. Although not explicitly stated, I assume this is the same for the "get users" endpoint (https://www.keycloak.org/docs-api/17.0/rest-api/index.html#_getusers)

In this PR I've simply replicated what was there for the `GetUsersAsync` method for the query parameters declared in the documentation.
